### PR TITLE
Feature: prevent git from tracking obsidian configurations in `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Created by https://www.toptal.com/developers/gitignore/api/obsidian
+# Edit at https://www.toptal.com/developers/gitignore?templates=obsidian
+
+### Obsidian ###
+# config dir
+.obsidian/
+
+# End of https://www.toptal.com/developers/gitignore/api/obsidian


### PR DESCRIPTION
# Feature: prevent git from tracking obsidian configurations in `.gitignore`
This pull request closes #4.

## Overview
 - **Issue:** Unnecessary settings leaks for Obsidian workspace settings.
 - **Background**: Using Obsidian at the root folder of the project creates some workspace user-specific settings, that are not meant to be tracked within this repository.
 - **Related Solutions / Dependencies:**  - 
 - **Impact:** Better user/developer experience while using [Obsidian][obsidian], improving the overall organization, enhancing the learning and developing experience.

## Descriptions
This Pull Request solves the Obsidian configurations from being tracked by the git history control, adding an exception into `.gitignore` file. 

## Changes Made
 - Create `.gitignore` configuration file
 - Add git restrictions for Obsidian config paths   

## Notes and References
 - [Git Ignore Documentation][git-ignore]
 - [Git Ignore Generator][git-ignore-io]

[git-ignore]: https://git-scm.com/docs/gitignore
[git-ignore-io]: https://www.toptal.com/developers/gitignore
[obsidian]: [https://obsidian.md/]