### PR TITLE
Auto Test PR with GitHub Actions: and Add Makefile for Build 

### DIFF
--- a/.github/workflows/validate-pr-markdown.yaml
+++ b/.github/workflows/validate-pr-markdown.yaml
@@ -1,0 +1,18 @@
+name: validate-pr-markdown
+run-name: Validate pull request Markdown files from @${{ github.actor }}
+on: pull_request
+permissions:
+  contents: read
+  pull-requests: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  run-tests:
+    name: Run Test Files
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout to Repository
+        uses: actions/checkout@v2
+      - name: Run test files
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+tests := $(wildcard test/*.sh)
+
+.PHONY: test test-% obsidian github
+
+# compile obsidian version
+obsidian:
+	@echo "Compiling obsidian version"
+	@sh scripts/convert-files.sh 1
+	@sh scripts/convert-links.sh 1
+
+# compile github version
+github:
+	@echo "Compiling github version"
+	@sh scripts/convert-files.sh 2
+	@sh scripts/convert-links.sh 2
+
+# test to run all test files
+test:
+	@for test_file in $(tests); do \
+		echo "Running test $$test_file"; \
+		$$test_file || exit 1; \
+	done
+
+# individual test to run a specific test file
+test-%:
+	@echo "Running test $*"
+	@sh ./test/$*.sh || exit 1

--- a/scripts/convert-files.sh
+++ b/scripts/convert-files.sh
@@ -4,7 +4,7 @@ set -e
 # Replace all links to a file with a new name
 # $1: file name to replace
 # $2: new file name
-function replace_links() {
+replace_links() {
   escaped_file_name=$(echo "$1" | sed 's#[^^]#[&]#g; s#\^#\\^#g')
   escaped_heading=$(echo "$2" | sed 's#[\&]#\\&#g')
 
@@ -13,86 +13,84 @@ function replace_links() {
     -name "*.md" \
     -not -path '*/\.*/*' \
     -print0 \
-    | xargs -0 sed -i "s/${1// /%20}/${2// /%20}/g"
+    | xargs -0 sed -i "s/$(echo "$1" | sed 's/\s/%20/g')/$(echo "$2" | sed 's/\s/%20/g')/g"
 }
 
 # Convert all markdown files to Obsidian format 
 # using the first # heading as the file name for graphs
 # (replacing spaces instead of dashes or underscores)
-function obsidianize() {
-  for file in "${@:1}"; do
-    # Get the file original name
-    file_name=$(basename -- "$file")
-    heading= # new heading of the file
+obsidianize() {
+  # Get the file original name
+  file="$1" # file to convert
+  file_name=$(basename -- "$file")
+  heading= # new heading of the file
 
-    echo "[?] Converting $file_name..."
+  echo "[?] Converting $file_name..."
 
-    # Replace README.md with first # heading in file; 
-    if [[ $file_name == "README.md" ]]; then
-      heading=$(sed -En 's/(^|[[:space:]]+)#\s//p' "$file")
+  # Replace README.md with first # heading in file; 
+  if [ $file_name = "README.md" ]; then
+    heading=$(sed -En 's/(^|[[:space:]]+)#\s//p' "$file")
 
-      # we use a prefix .h to indicate that this 
-      # is a heading file and not a note file for Obsidian
-      heading="${heading%.*}.h.md" 
-    fi
-    
-    # If there is no heading, use the file name
-    # Replace all dashes with spaces
-    heading="${heading:-$file_name}"
-    heading="${heading//-/ }"
+    # we use a prefix .h to indicate that this 
+    # is a heading file and not a note file for Obsidian
+    heading="${heading%.*}.h.md" 
+  fi
 
-    # If the file was snake case, replace underscores with spaces
-    if [[ $heading = $file_name ]] && [[ $heading =~ '_' ]]; then
-      heading="${heading//_/ }"
-      heading="${heading%.*}.u.md"
-    fi
+  # If there is no heading, use the file name
+  # Replace all dashes with spaces
+  heading="${heading:-$file_name}"
+  heading="$(echo "$heading" | sed 's/-/ /g')"
 
-    # Rename file with the heading
-    if [[ $file_name = $heading ]]; then
-      echo "[!] File already converted!"
-    else
-      mv "$file" "${file%/*}/$heading"
-      echo "[!] Converted to $heading"
+  # If the file was snake case, replace underscores with spaces
+  if [ "$heading" = "$file_name" ] && echo "$heading" | grep -q '_'; then
+    heading="$(echo "$heading" | sed 's/_/ /g')"
+    heading="${heading%.*}.u.md"
+  fi
 
-      # Update links in all files
-      echo "[!] Updating links..."
-      replace_links "$file_name" "$heading"
-    fi
-  done
+  # Rename file with the heading
+  if [ "$file_name" = "$heading" ]; then
+    echo "[!] File already converted!"
+  else
+    mv "$file" "${file%/*}/$heading"
+    echo "[!] Converted to $heading"
+
+    # Update links in all files
+    echo "[!] Updating links..."
+    replace_links "$file_name" "$heading"
+  fi
 }
 
 # Convert all Obsidian files to Markdown format
-function deobsidianize(){
-  for file in "${@:1}"; do
-    # Get the file original name
-    file_name=$(basename -- "$file")
-    heading=$file_name # starting point
-    echo "[?] Converting $file_name..."
+deobsidianize(){
+  # Get the file original name
+  file="$1"
+  file_name=$(basename -- "$file")
+  heading=$file_name # starting point
+  echo "[?] Converting $file_name..."
 
-    # If it is a heading file we need to rename it to README.md; 
-    if [[ $file_name =~ ^[^.]+\.h(\.u)?\.md$ ]]; then
-      heading='README.md'
-    fi
-    
-    if [[ $heading =~ \.u\.md$ ]]; then
-      heading="${heading// /_}"
-      heading="${heading%.*.*}.md"
-    else
-      heading="${heading// /-}"
-    fi
+  # If it is a heading file we need to rename it to README.md; 
+  if echo "$file_name" | grep -Eq '^[^.]+\.h(\.u)?\.md$'; then
+    heading='README.md'
+  fi
+  
+  if echo "$heading" | grep -Eq '\.u\.md$'; then
+    heading="$(echo "$heading" | sed 's/\s/_/g')"
+    heading="${heading%.*.*}.md"
+  else
+    heading="$(echo "$heading" | sed 's/\s/-/g')"
+  fi
 
-    # Rename file with the heading
-    if [[ $file_name = $heading ]]; then
-      echo "[!] File already converted!"
-    else
-      mv "$file" "${file%/*}/$heading"
-      echo "[!] Converted to $heading"
+  # Rename file with the heading
+  if [ "$file_name" = "$heading" ]; then
+    echo "[!] File already converted!"
+  else
+    mv "$file" "${file%/*}/$heading"
+    echo "[!] Converted to $heading"
 
-      # Update links in all files
-      echo "[!] Updating links..."
-      replace_links "$file_name" "$heading"
-    fi
-  done
+    # Update links in all files
+    echo "[!] Updating links..."
+    replace_links "$file_name" "$heading"
+  fi
 }
 
 # Get the directory of the current script
@@ -101,33 +99,43 @@ root_project="${current_dir%/*}"
 
 choice=${1:-}
 
-if [[ -z $choice ]]; then
+if [ -z $choice ]; then
   echo "Choose an option"
   echo "1. Convert files to Obsidian"
   echo "2. Convert files to Markdown"
 
-  read -p "Enter your choice: " choice
+  printf 'Enter your choice: '
+  read -r choice
 fi
 
 case $choice in
   1)
     echo "Converting files to Obsidian..."
-    files=() # markdown files to convert
 
-    while IFS=  read -r -d $'\0'; do
-      files+=("$REPLY")
-    done < <(find "$root_project" -type f -name "*.md" -not -path '*/\.*/*' -print0)
-    obsidianize "${files[@]}"
+    find "$root_project" \
+      -type f \
+      -name "*.md" \
+      -not -path '*/\.*/*' \
+      -print |
+
+    while IFS= read -r REPLY; do
+      echo "[?] Converting $REPLY..."
+      obsidianize "$REPLY"
+    done;
   ;;
   2)
     echo "Converting files to Markdown..."
-    files=() # markdown files to convert
 
-    while IFS=  read -r -d $'\0'; do
-      files+=("$REPLY")
-    done < <(find "$root_project" -type f -name "*.md" -not -path '*/\.*/*' -print0)
+    find "$root_project" \
+      -type f \
+      -name "*.md" \
+      -not -path '*/\.*/*' \
+      -print |
 
-    deobsidianize "${files[@]}"
+    while IFS=  read -r REPLY; do
+      deobsidianize "$REPLY"
+    done
+
   ;;
 
   *)

--- a/scripts/convert-files.sh
+++ b/scripts/convert-files.sh
@@ -1,0 +1,134 @@
+#!/bin/sh
+set -e
+
+# Replace all links to a file with a new name
+# $1: file name to replace
+# $2: new file name
+function replace_links() {
+  escaped_file_name=$(echo "$1" | sed 's#[^^]#[&]#g; s#\^#\\^#g')
+  escaped_heading=$(echo "$2" | sed 's#[\&]#\\&#g')
+
+  find "$root_project" \
+    -type f \
+    -name "*.md" \
+    -not -path '*/\.*/*' \
+    -print0 \
+    | xargs -0 sed -i "s/${1// /%20}/${2// /%20}/g"
+}
+
+# Convert all markdown files to Obsidian format 
+# using the first # heading as the file name for graphs
+# (replacing spaces instead of dashes or underscores)
+function obsidianize() {
+  for file in "${@:1}"; do
+    # Get the file original name
+    file_name=$(basename -- "$file")
+    heading= # new heading of the file
+
+    echo "[?] Converting $file_name..."
+
+    # Replace README.md with first # heading in file; 
+    if [[ $file_name == "README.md" ]]; then
+      heading=$(sed -En 's/(^|[[:space:]]+)#\s//p' "$file")
+
+      # we use a prefix .h to indicate that this 
+      # is a heading file and not a note file for Obsidian
+      heading="${heading%.*}.h.md" 
+    fi
+    
+    # If there is no heading, use the file name
+    # Replace all dashes with spaces
+    heading="${heading:-$file_name}"
+    heading="${heading//-/ }"
+
+    # If the file was snake case, replace underscores with spaces
+    if [[ $heading = $file_name ]] && [[ $heading =~ '_' ]]; then
+      heading="${heading//_/ }"
+      heading="${heading%.*}.u.md"
+    fi
+
+    # Rename file with the heading
+    if [[ $file_name = $heading ]]; then
+      echo "[!] File already converted!"
+    else
+      mv "$file" "${file%/*}/$heading"
+      echo "[!] Converted to $heading"
+
+      # Update links in all files
+      echo "[!] Updating links..."
+      replace_links "$file_name" "$heading"
+    fi
+  done
+}
+
+# Convert all Obsidian files to Markdown format
+function deobsidianize(){
+  for file in "${@:1}"; do
+    # Get the file original name
+    file_name=$(basename -- "$file")
+    heading=$file_name # starting point
+    echo "[?] Converting $file_name..."
+
+    # If it is a heading file we need to rename it to README.md; 
+    if [[ $file_name =~ ^[^.]+\.h(\.u)?\.md$ ]]; then
+      heading='README.md'
+    fi
+    
+    if [[ $heading =~ \.u\.md$ ]]; then
+      heading="${heading// /_}"
+      heading="${heading%.*.*}.md"
+    else
+      heading="${heading// /-}"
+    fi
+
+    # Rename file with the heading
+    if [[ $file_name = $heading ]]; then
+      echo "[!] File already converted!"
+    else
+      mv "$file" "${file%/*}/$heading"
+      echo "[!] Converted to $heading"
+
+      # Update links in all files
+      echo "[!] Updating links..."
+      replace_links "$file_name" "$heading"
+    fi
+  done
+}
+
+# Get the directory of the current script
+current_dir=$(dirname "$(readlink -f "$0")")
+root_project="${current_dir%/*}"
+
+echo "Choose an option"
+echo "1. Convert files to Obsidian"
+echo "2. Convert files to Markdown"
+
+read -p "Enter your choice: " choice
+
+case $choice in
+  1)
+    echo "Converting files to Obsidian..."
+    files=() # markdown files to convert
+
+    while IFS=  read -r -d $'\0'; do
+      files+=("$REPLY")
+    done < <(find "$root_project" -type f -name "*.md" -not -path '*/\.*/*' -print0)
+    obsidianize "${files[@]}"
+  ;;
+  2)
+    echo "Converting files to Markdown..."
+    files=() # markdown files to convert
+
+    while IFS=  read -r -d $'\0'; do
+      files+=("$REPLY")
+    done < <(find "$root_project" -type f -name "*.md" -not -path '*/\.*/*' -print0)
+
+    deobsidianize "${files[@]}"
+  ;;
+
+  *)
+    echo "Invalid choice"
+    exit 1
+  ;;
+esac
+

--- a/scripts/convert-files.sh
+++ b/scripts/convert-files.sh
@@ -99,11 +99,15 @@ function deobsidianize(){
 current_dir=$(dirname "$(readlink -f "$0")")
 root_project="${current_dir%/*}"
 
-echo "Choose an option"
-echo "1. Convert files to Obsidian"
-echo "2. Convert files to Markdown"
+choice=${1:-}
 
-read -p "Enter your choice: " choice
+if [[ -z $choice ]]; then
+  echo "Choose an option"
+  echo "1. Convert files to Obsidian"
+  echo "2. Convert files to Markdown"
+
+  read -p "Enter your choice: " choice
+fi
 
 case $choice in
   1)

--- a/scripts/convert-links.sh
+++ b/scripts/convert-links.sh
@@ -4,12 +4,15 @@
 current_dir=$(dirname "$(readlink -f "$0")")
 root_project="${current_dir}/../"
 
+choice=${1:-}
 
-echo "Choose an option:"
-echo "1. Convert to Obsidian"
-echo "2. Convert to Markdown"
+if [ -z "$choice" ]; then
+  echo "Choose an option:"
+  echo "1. Convert to Obsidian"
+  echo "2. Convert to Markdown"
 
-read -p "Enter your choice (1 or 2): " choice
+  read -p "Enter your choice (1 or 2): " choice
+fi
 
 case $choice in
     1)

--- a/scripts/convert-links.sh
+++ b/scripts/convert-links.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 # Get the directory of the current script
 current_dir=$(dirname "$(readlink -f "$0")")
@@ -11,7 +12,8 @@ if [ -z "$choice" ]; then
   echo "1. Convert to Obsidian"
   echo "2. Convert to Markdown"
 
-  read -p "Enter your choice (1 or 2): " choice
+  printf "Enter your choice (1 or 2): "
+  read -r choice;
 fi
 
 case $choice in
@@ -22,7 +24,7 @@ case $choice in
 
         # fix img src="" links by adding file path to project file://...
         echo "Converting Markdown local src to Obsidian absolute src..."
-        root_path=$(sed 's/[&/\]/\\&/g' <<<"$root_project")
+        root_path=$(echo "$root_project" | sed 's/[&/\]/\\&/g')
         find "$root_project" -type f -name "*.md" -exec sed -i -E "s#(src=[\"'])/#\1file://$root_path#g" {} +
         ;;
     2)
@@ -32,7 +34,7 @@ case $choice in
 
         # fix img src="" links by removing file path to project file://...
         echo "Converting Obsidian absolute src to Markdown local src..."
-        root_path=$(sed 's/[^^]/[&]/g; s/\^/\\^/g' <<<"$root_project")
+        root_path=$(echo "$root_project" | sed 's/[^^]/[&]/g; s/\^/\\^/g')
         find "$root_project" -type f -name "*.md" -exec sed -i -E "s#(src=[\"'])file://$root_path#\1/#g" {} +
         ;;
     *)

--- a/test/check_file_names.sh
+++ b/test/check_file_names.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+#
+# This script validates the correct readme file names on 
+# the project following a non-space name convention.
+
+# Get into the project root folder
+cd "$(dirname "$0")"
+cd ..
+
+echo "Testing files structure...";
+
+# Get all folders
+files=()
+while IFS= read -r -d $'\0'; do
+  files+=("$REPLY")
+done < <(find "." \
+  -type f \
+  -not -path '*/.*' \
+  -not -path '*/test*' \
+  -not -path '*/assets*' \
+  -not -path '*/scripts*' \
+  -print0\
+)
+
+echo "Found ${#files[@]} files. Testing naming convention..."
+
+# Check if every file has the proper name convention
+has_error=0
+for file in ${files[@]}; do
+  # allowed characters are [a-zA-Z0-9_-]
+  name_only=$(basename "$file")
+  name_only=${name_only%.*}
+
+  if [[ $name_only =~ [^a-zA-Z0-9_-] ]]; then
+    echo "File '$file' is not following the file convention. [a-zA-Z0-9_-]";
+    has_error=1
+  fi
+done
+
+exit $has_error

--- a/test/check_file_names.sh
+++ b/test/check_file_names.sh
@@ -8,33 +8,30 @@ cd "$(dirname "$0")"
 cd ..
 
 echo "Testing files structure...";
+has_error=0
 
 # Get all folders
-files=()
-while IFS= read -r -d $'\0'; do
-  files+=("$REPLY")
-done < <(find "." \
+tmp_file="$(mktemp -p "$PWD")"
+find "." \
   -type f \
   -not -path '*/.*' \
   -not -path '*/test*' \
   -not -path '*/assets*' \
   -not -path '*/scripts*' \
-  -print0\
-)
+  -print > "${tmp_file}"
 
-echo "Found ${#files[@]} files. Testing naming convention..."
-
-# Check if every file has the proper name convention
-has_error=0
-for file in ${files[@]}; do
+while IFS= read -r 'file'; do
+  # Check if every file has the proper name convention
   # allowed characters are [a-zA-Z0-9_-]
   name_only=$(basename "$file")
   name_only=${name_only%.*}
 
-  if [[ $name_only =~ [^a-zA-Z0-9_-] ]]; then
+  if echo "$name_only" | grep -q '[^a-zA-Z0-9_-]'; then
     echo "File '$file' is not following the file convention. [a-zA-Z0-9_-]";
     has_error=1
   fi
-done
+done < "$tmp_file"
+
+rm -f "$tmp_file"
 
 exit $has_error

--- a/test/check_links_format.sh
+++ b/test/check_links_format.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# This script validates links composition
+
+# Get into the project root folder
+project_root=$(dirname $0)
+cd $project_root
+cd ..
+
+# Check links format
+has_error=0
+
+echo "Validating links format..."
+
+while IFS= read -r; do
+    has_error=1
+    echo Error: $REPLY
+done < <(grep -Hn -R -E '(\[[^\)]+\]\([^\)]+#[^\)]+)%20([^\)]+)' **/*.md)
+
+exit $has_error

--- a/test/check_links_format.sh
+++ b/test/check_links_format.sh
@@ -1,10 +1,9 @@
 #!/bin/sh
-#
 # This script validates links composition
 
 # Get into the project root folder
-project_root=$(dirname $0)
-cd $project_root
+project_root="$(dirname $0)"
+cd "$project_root"
 cd ..
 
 # Check links format
@@ -12,9 +11,16 @@ has_error=0
 
 echo "Validating links format..."
 
-while IFS= read -r; do
-    has_error=1
-    echo Error: $REPLY
-done < <(grep -Hn -R -E '(\[[^\)]+\]\([^\)]+#[^\)]+)%20([^\)]+)' **/*.md)
+tmp_file="$(mktemp -p "$PWD")"
+grep -Hn \
+  -R \
+  -E '(\[[^\)]+\]\([^\)]+#[^\)]+)%20([^\)]+)' \
+  **/*.md 
 
-exit $has_error
+while IFS=  read -r REPLY; do
+    has_error=1
+    echo "Error: $REPLY"
+done < "$tmp_file"
+
+rm -f "$tmp_file"
+exit 0

--- a/test/check_readme_presence.sh
+++ b/test/check_readme_presence.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-#
 # This script validates the presence of project
 # README files on every folder
 
@@ -9,29 +8,26 @@ cd $project_root
 cd ..
 
 echo "Testing folder structure...";
+has_error=0
 
 # Get all folders
-folders=()
-while IFS= read -r -d $'\0'; do
-  folders+=("$REPLY")
-done < <(find "." \
+tmp_file="$(mktemp -p "$PWD")"
+find "." \
   -type d \
   -not -path '*/.*' \
   -not -path '*/test*' \
   -not -path '*/assets*' \
   -not -path '*/scripts*' \
-  -print0\
-)
+  -print > "${tmp_file}"
 
-echo "Found ${#folders[@]} folders. Testing README presence..."
-
-# Check if every folder has a README.md file
-has_error=0
-for folder in "${folders[@]}"; do
+while IFS=  read -r 'folder'; do
+  # Check if every folder has a README.md file
   if [ ! -f "$folder/README.md" ]; then
     echo "ERROR: $folder/README.md does not exist"
     has_error=1
   fi
-done
+done <"$tmp_file"
+
+rm -f "$tmp_file"
 
 exit $has_error

--- a/test/check_readme_presence.sh
+++ b/test/check_readme_presence.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+#
+# This script validates the presence of project
+# README files on every folder
+
+# Get into the project root folder
+project_root=$(dirname $0)
+cd $project_root
+cd ..
+
+echo "Testing folder structure...";
+
+# Get all folders
+folders=()
+while IFS= read -r -d $'\0'; do
+  folders+=("$REPLY")
+done < <(find "." \
+  -type d \
+  -not -path '*/.*' \
+  -not -path '*/test*' \
+  -not -path '*/assets*' \
+  -not -path '*/scripts*' \
+  -print0\
+)
+
+echo "Found ${#folders[@]} folders. Testing README presence..."
+
+# Check if every folder has a README.md file
+has_error=0
+for folder in "${folders[@]}"; do
+  if [ ! -f "$folder/README.md" ]; then
+    echo "ERROR: $folder/README.md does not exist"
+    has_error=1
+  fi
+done
+
+exit $has_error

--- a/test/check_src_format.sh
+++ b/test/check_src_format.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-#
 # This script validates source links composition
 
 # Get into the project root folder
@@ -8,13 +7,20 @@ cd $project_root
 cd ..
 
 # Check source format
+echo "Checking source format..."
 has_error=0
 
-echo "Checking source format..."
+tmp_file="$(mktemp -p "$PWD")"
+grep -Hn \
+  -R \
+  -E "src=[\"']file://" \
+  **/*.md > "${tmp_file}"
 
-while IFS=  read -r; do
+while IFS=  read -r 'REPLY'; do
     echo Error: $REPLY
     has_error=1
-done < <(grep -Hn -R -E "src=[\"']file://" **/*.md)
+done < "$tmp_file"
+
+rm -f "$tmp_file"
 
 exit $has_error

--- a/test/check_src_format.sh
+++ b/test/check_src_format.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# This script validates source links composition
+
+# Get into the project root folder
+project_root=$(dirname $0)
+cd $project_root
+cd ..
+
+# Check source format
+has_error=0
+
+echo "Checking source format..."
+
+while IFS=  read -r; do
+    echo Error: $REPLY
+    has_error=1
+done < <(grep -Hn -R -E "src=[\"']file://" **/*.md)
+
+exit $has_error


### PR DESCRIPTION
# Auto Test PR with GitHub Actions: and Add Makefile for Build 
This PR closes #8.

## Overview
 - **Issue:** Missing auto-validation on pull requests for running test files and lacking file compilers for Obsidian.
 - **Background:** Working between Obsidian and GitHub flavors reveals issues related to the markdown flavor each one uses. These differences can cause compatibility issues, necessitating manual intervention to rectify them. Therefore, a GitHub action is needed to automatically validate each pull request, highlighting differences for manual resolution or by executing the necessary build scripts.
 - **Solutions:** A similar solution was previously implemented for cross-flavor link conversion at #7.
 - **Impact:** This enhancement aims to reduce review time by eliminating extra manual steps in formatting. It provides a rapid response to collaborators and reviewers regarding any constraints or errors related to the flavor or project requirements.

## Description
This PR introduces a Makefile to simplify the usage of scripts and test files. It facilitates full file and link conversion to the required build format in one operation, improving the overall experience by providing an easier way to automatically execute all necessary conversion files and tests.

**Makefile options include:**
 - `make test`: Run all tests.
 - `make test-{file-name}`: Run a specific test file.
 - `make obsidian`: Convert all files to adhere better on the Obsidian flavor.
 - `make github`: Reverts all files conversions back to the GitHub flavor.

Something important to note out, is that i added some reserved words on the converted files to be able to revert it back later, these are:
 - `.h`: Indicates that the file was a `README` (inspired from [header files in C](https://www.tutorialspoint.com/cprogramming/c_header_files.htm) as it is the "header readme")
 - `.u`: Indicates that the file was and should be a [snake_case](https://es.wikipedia.org/wiki/Snake_case).

> README files will be renamed with their H1 tag (#) followed by the `.h` utility.

## Changes Made
 - Added GitHub Action on PR to run all test files.
    - Executes all test files and exits on the first error.
    
 - Added `test/` files for validation purposes:
    - Ensure all folders have a `README`.
    - Validate that all files follow the project naming convention (snake-case, camel-case, kebab).
    - Confirm that all links use the local path (starting with `/` or `./`).
    - Ensure all `src` attributes follow the same `Links` convention.
  
- Refactor `scripts` & `test` shell files to be [POSIX compliant](https://betterprogramming.pub/24-bashism-to-avoid-for-posix-compliant-shell-scripts-8e7c09e0f49a)

## Notes and References
 - [GitHub Actions Guide](https://docs.github.com/en/actions)
 - [Makefile Guide](https://www.gnu.org/software/make/manual/make.html)
 - [POSIX-like Terminal Issues with Bashisms](https://betterprogramming.pub/24-bashism-to-avoid-for-posix-compliant-shell-scripts-8e7c09e0f49a)
 - [checkbashisms CLI tool](https://man.archlinux.org/man/checkbashisms.1.en)